### PR TITLE
fix regex for urls with inline params

### DIFF
--- a/src/schema-generator.js
+++ b/src/schema-generator.js
@@ -97,9 +97,7 @@ const getMapper = (restDirective, bodyMappers) => {
 }
 
 const parseParams = url =>
-  url
-    .split(new RegExp('[?./=]'))
-    .filter(part => part.charAt(0) === ':')
+  (url.match(/:([a-zA-Z0-9]+)/g)||[])
     .map(part => part.substr(1))
 
 const getProvidesValues = (providesMappings, parentObject) =>

--- a/src/schema-generator.js
+++ b/src/schema-generator.js
@@ -98,7 +98,7 @@ const getMapper = (restDirective, bodyMappers) => {
 
 const parseParams = url =>
   url
-    .split('/')
+    .split(new RegExp('[?./=]'))
     .filter(part => part.charAt(0) === ':')
     .map(part => part.substr(1))
 


### PR DESCRIPTION
Fixes the param parsing for URLs. For example the New York Times API has the format:
`https://api.nytimes.com/svc/topstories/v2/:section.:format?api-key=:apiKey`
In which case the current regex will look for a param called `format?api-key=` which is probably not the expected behavior.