### PR TITLE
Mappers for query strings, request bodies and responses

### DIFF
--- a/src/__tests__/schema-generator.test.js
+++ b/src/__tests__/schema-generator.test.js
@@ -13,7 +13,8 @@ const typeDefs = gql`
 
   type Query {
     user(id: ID!): User @rest(route: "/users/:id")
-    color(id: ID!): Color @rest(route: "/color/:id", mapper: "ColorMapper")
+    color(id: ID!): Color
+      @rest(route: "/color/:id", responseMapper: "ColorMapper")
     colors(first: Int!, after: ID): [Color]!
       @rest(route: "/colors", query: { first: "first", after: "after" })
   }
@@ -40,12 +41,12 @@ const typeDefs = gql`
   }
 `
 
-const mappers = {
+const responseMappers = {
   ColorMapper: payload => payload.data,
 }
 
 const createRestSchema = (opts = {}) =>
-  generateRestSchema({ typeDefs, mappers, ...opts })
+  generateRestSchema({ typeDefs, responseMappers, ...opts })
 
 describe(`General`, () => {
   it(`Can generate resolvers`, async () => {
@@ -256,7 +257,7 @@ describe(`General`, () => {
     })
   })
 
-  it(`supports a body mapper`, async () => {
+  it(`supports a response mapper`, async () => {
     expect.assertions(1)
 
     const fetcher = fetchMock.sandbox().get(`/color/red`, {

--- a/src/schema-generator.js
+++ b/src/schema-generator.js
@@ -87,15 +87,14 @@ const getQueryMappings = (restDirective, args) => {
 }
 
 const getQueryValues = (queryMappings, params) =>
-  queryMappings
-    .reduce((acc, { queryField, paramName }) => {
-      const param = params.find(param => param.name === paramName)
+  queryMappings.reduce((acc, { queryField, paramName }) => {
+    const param = params.find(param => param.name === paramName)
 
-      if (param && param.value !== undefined) {
-        acc.push({ queryField, queryValue: param.value })
-      }
-      return acc
-    }, [])
+    if (param && param.value !== undefined) {
+      acc.push({ queryField, queryValue: param.value })
+    }
+    return acc
+  }, [])
 
 const getMapper = (restDirective, argName, mappers) => {
   const arg = restDirective.arguments.find(
@@ -103,7 +102,7 @@ const getMapper = (restDirective, argName, mappers) => {
   )
   if (!arg) return _ => _
   const mapper = mappers[arg.value.value]
-  if (!mapper) throw new Error(`Missing mapper '${arg.value.value}'`)
+  if (!mapper) throw new Error(`Missing ${argName} '${arg.value.value}'.`)
   return mapper
 }
 
@@ -136,10 +135,11 @@ const checkRequiredParams = (requiredParams, params) =>
     if (!param) throw new Error(`Missing param '${requiredParam}'`)
   })
 
-const generateQueryString = (queryValues) =>
+const generateQueryString = queryValues =>
   queryValues
-    .map(({ queryField, queryValue }) =>
-      queryField + '=' + encodeURIComponent(queryValue)
+    .map(
+      ({ queryField, queryValue }) =>
+        queryField + '=' + encodeURIComponent(queryValue),
     )
     .join('&')
 
@@ -156,11 +156,7 @@ const createFieldResolver = (
   field,
   objectTypeDefinition,
   fetcher,
-  {
-    queryMappers = {},
-    requestMappers = {},
-    responseMappers = {},
-  },
+  { queryMappers = {}, requestMappers = {}, responseMappers = {} },
 ) => {
   const { arguments: args, name: { value: fieldName } } = field
   const restDirective = getRestDirective(field)
@@ -177,12 +173,17 @@ const createFieldResolver = (
   const argumentMappings = getArgumentMappings(restDirective, args)
   const bodyMappings = getBodyMappings(restDirective, args)
   const queryMappings = getQueryMappings(restDirective, args)
-  const queryMapper =
-    getMapper(restDirective, `queryMapper`, queryMappers)
-  const requestMapper =
-    getMapper(restDirective, `requestMapper`, requestMappers)
-  const responseMapper =
-    getMapper(restDirective, `responseMapper`, responseMappers)
+  const queryMapper = getMapper(restDirective, `queryMapper`, queryMappers)
+  const requestMapper = getMapper(
+    restDirective,
+    `requestMapper`,
+    requestMappers,
+  )
+  const responseMapper = getMapper(
+    restDirective,
+    `responseMapper`,
+    responseMappers,
+  )
 
   if (method === `GET` && bodyMappings.length)
     throw new Error(

--- a/src/schema-generator.js
+++ b/src/schema-generator.js
@@ -151,6 +151,7 @@ const createFieldResolver = (
   objectTypeDefinition,
   fetcher,
   {
+    requestMappers = {},
     responseMappers = {},
   },
 ) => {
@@ -169,6 +170,8 @@ const createFieldResolver = (
   const argumentMappings = getArgumentMappings(restDirective, args)
   const bodyMappings = getBodyMappings(restDirective, args)
   const queryMappings = getQueryMappings(restDirective, args)
+  const requestMapper =
+    getMapper(restDirective, `requestMapper`, requestMappers)
   const responseMapper =
     getMapper(restDirective, `responseMapper`, responseMappers)
 
@@ -191,7 +194,7 @@ const createFieldResolver = (
 
     let body = undefined
     if (bodyMappings.length) {
-      body = JSON.stringify(getBodyValues(bodyMappings, params))
+      body = JSON.stringify(requestMapper(getBodyValues(bodyMappings, params)))
     }
 
     return fetcher(generatedRoute, {


### PR DESCRIPTION
Hey,

This PR addresses #14.

1. The `mapper` directive argument is renamed to `responseMapper`.
This is a **breaking change**. I can make this PR backward compatible if you want to (at the cost of more code additions).

2. Add `requestMapper`.
It allows to transforms the request body prior to submitting the request.
`{ input: { name: 'yellow' } }` can be changed to `{ name: 'yellow' }` for example.

3. Add `queryMapper`.
It allows to transform query string parameters, like to change a parameter value or add an extra parameter.

Note that `requestMapper` works together with `body`. It is applied to the result of the `body` mapping. That’s my preferred approach. Another approach could be to forbid to use `requestMapper` and `body` together. `requestMapper` would then have to do what `body` currently does plus any extra transformation.

Same for `queryMapper`, it works together with `query`.

I’m happy to change anything.
Cheers,